### PR TITLE
fix missing terraform icon

### DIFF
--- a/lua/nvim-web-devicons/override.lua
+++ b/lua/nvim-web-devicons/override.lua
@@ -21,6 +21,7 @@ local palette = {
   bright_blue = "#79b8ff",
   magenta = "#b392f0",
   bright_magenta = "#b392f0",
+  purple = "#5F43E9",
   cyan = "#39c5cf",
   bright_cyan = "#56d4dd",
 }
@@ -831,6 +832,11 @@ devicons.set_icon({
     color = palette.bright_black,
     name = "Terminal",
   },
+  ["tf"] = {
+      icon = get("terraform"),
+      color = palette.purple,
+      name = "Terraform"
+  }
   -- ["pdf"] = {
   --   icon = "",
   --   color = "#b30b00",


### PR DESCRIPTION
Hi, @yamatsum Could you please help to review this PR? It seems missing configure for terraform icon

Before displaying
<img width="185" alt="Screenshot 2023-02-05 at 00 50 17" src="https://user-images.githubusercontent.com/40130936/216782070-9af04a1a-0d5b-4f6f-a694-9f114db66304.png">


After displaying
<img width="185" alt="Screenshot 2023-02-05 at 00 49 49" src="https://user-images.githubusercontent.com/40130936/216782054-c45ffbb4-7de0-47cd-b611-f02ceace007f.png">

